### PR TITLE
Add `useSourceTokenForButtonText` option for button text to SendForm component

### DIFF
--- a/packages/anypay-sdk/src/widget/widget.tsx
+++ b/packages/anypay-sdk/src/widget/widget.tsx
@@ -73,6 +73,7 @@ export type AnyPayWidgetProps = {
   walletOptions?: string[]
   onOriginConfirmation?: (txHash: string) => void
   onDestinationConfirmation?: (txHash: string) => void
+  useSourceTokenForButtonText?: boolean
 }
 
 const queryClient = new QueryClient()
@@ -118,6 +119,7 @@ const WidgetInner: React.FC<AnyPayWidgetProps> = ({
   walletOptions,
   onOriginConfirmation,
   onDestinationConfirmation,
+  useSourceTokenForButtonText,
 }) => {
   const { address, isConnected, chainId, connector } = useAccount()
   const [theme, setTheme] = useState<ActiveTheme>(getInitialTheme(initialTheme))
@@ -451,6 +453,7 @@ const WidgetInner: React.FC<AnyPayWidgetProps> = ({
             walletClient={walletClient}
             theme={theme}
             onTransactionStateChange={handleTransactionStateChange}
+            useSourceTokenForButtonText={useSourceTokenForButtonText}
           />
         ) : (
           <div


### PR DESCRIPTION
Fixes: https://sequence-xyz.slack.com/archives/C08STR1743H/p1750071064878739?thread_ts=1749648796.378269&cid=C08STR1743H

Add option for:

> And a small UX feedback: the button says "Spend 0.00002 ETH", I would rather display "Spend X of [source token]" instead.

